### PR TITLE
Turn off vignette compilation on Windows.

### DIFF
--- a/vignettes/UsingAnnoyInCpp.Rmd
+++ b/vignettes/UsingAnnoyInCpp.Rmd
@@ -37,9 +37,10 @@ vignette: >
 
 ```{r, echo=FALSE, results="hide"}
 knitr::opts_chunk$set(error=FALSE, warning=FALSE, message=FALSE, eval=FALSE)
+is.win <- .Platform$OS.type=="windows" # doesn't compile with knitr on Windows, for some reason.
 ```
 
-```{Rcpp, ref.label=knitr::all_rcpp_labels(), include=FALSE, eval=TRUE}
+```{Rcpp, ref.label=knitr::all_rcpp_labels(), include=FALSE, eval=!is.win}
 ```
 
 # Setting up your package 
@@ -208,7 +209,7 @@ An example of using the Annoy library via \pkg{RcppAnnoy} is available in the [\
 }
 ```
 
-```{r, echo=FALSE, results="hide", eval=TRUE}
+```{r, echo=FALSE, results="hide", eval=!is.win}
 # Checking that the function works.
 testfun(matrix(0, 10, 5))
 if (file.exists("annoy.index")) unlink("annoy.index")

--- a/vignettes/UsingAnnoyInCpp.Rmd
+++ b/vignettes/UsingAnnoyInCpp.Rmd
@@ -199,10 +199,6 @@ Any issues specific to the \pkg{RcppAnnoy} interface should be posted at its sep
 An example of using the Annoy library via \pkg{RcppAnnoy} is available in the [\pkg{BiocNeighbors}](https://bioconductor.org/packages/BiocNeighbors) package
 \citep{Bioc:BiocNeighbors}.
 
-```{r, eval=FALSE, include=FALSE, echo=FALSE}
-## not needed   sessionInfo()
-```
-
 ```{Rcpp, echo=FALSE}
 // Odds and ends to complete compilation.
     return Rcpp::IntegerVector(neighbor_index.begin(), neighbor_index.end());


### PR DESCRIPTION
Installs fine on Rhub (with the modification to the `annoylib.h` header mentioned in #37).

Well, TeX compilation error aside, but that was just a warning.