### PR TITLE
Inlined set_error_* functions for multiple include's.

### DIFF
--- a/inst/include/annoylib.h
+++ b/inst/include/annoylib.h
@@ -81,7 +81,7 @@ typedef signed __int64    int64_t;
   # include <alloca.h>
 #endif
 
-void set_error_from_errno(char **error, const char* msg) {
+inline void set_error_from_errno(char **error, const char* msg) {
   showUpdate("%s: %s (%d)\n", msg, strerror(errno), errno);
   if (error) {
     *error = (char *)malloc(256);  // TODO: win doesn't support snprintf
@@ -89,7 +89,7 @@ void set_error_from_errno(char **error, const char* msg) {
   }
 }
 
-void set_error_from_string(char **error, const char* msg) {
+inline void set_error_from_string(char **error, const char* msg) {
   showUpdate("%s\n", msg);
   if (error) {
     *error = (char *)malloc(strlen(msg) + 1);


### PR DESCRIPTION
Fixes LTLA/BiocNeighbors#10 as well as #57.