### PR TITLE
Allow for larger integer values to be printed correctly

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2025-11-21  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/include/annoylib.h: Cast node count (or index) to 'size_t'
-	and use	'%lud' in verbose printing to allow for non-int32_t indices
+	and use	'%zu' in verbose printing to allow for non-int32_t indices
 
 2025-07-21  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/inst/include/annoylib.h
+++ b/inst/include/annoylib.h
@@ -979,7 +979,7 @@ public:
       memcpy(_get(_n_nodes + (S)i), _get(_roots[i]), _s);
     _n_nodes += _roots.size();
 
-    if (_verbose) annoylib_showUpdate("has %lud nodes\n", (size_t) _n_nodes);
+    if (_verbose) annoylib_showUpdate("has %zu nodes\n", (size_t) _n_nodes);
     
     if (_on_disk) {
       if (!remap_memory_and_truncate(&_nodes, _fd,
@@ -1231,7 +1231,7 @@ protected:
     }
     
     _nodes_size = new_nodes_size;
-    if (_verbose) annoylib_showUpdate("Reallocating to %lud nodes: old_address=%p, new_address=%p\n", (size_t) new_nodes_size, old, _nodes);
+    if (_verbose) annoylib_showUpdate("Reallocating to %zu nodes: old_address=%p, new_address=%p\n", (size_t) new_nodes_size, old, _nodes);
   }
 
   void _allocate_size(S n, ThreadedBuildPolicy& threaded_build_policy) {
@@ -1313,7 +1313,7 @@ protected:
           bool side = D::side(m, n->v, _f, _random);
           children_indices[side].push_back(j);
         } else {
-          annoylib_showUpdate("No node for index %lud?\n", (size_t) j);
+          annoylib_showUpdate("No node for index %zu?\n", (size_t) j);
         }
       }
 


### PR DESCRIPTION
PR #81 notes that the print function used in verbose mode defaults to '%d' yet the templates may be instantiated with integers of larger capacity than the four-byte `int` aka `int32_t` we default to. 

So this PR changes this to print as '%zu' with a corresponding cast to `size_t`.